### PR TITLE
#74 Fixing issue with view plan button

### DIFF
--- a/frontend/src/components/page_content/page-content-template.js
+++ b/frontend/src/components/page_content/page-content-template.js
@@ -60,6 +60,8 @@ class PageContentTemplate extends React.Component {
   setProfileSaveCancel() {
     if (this.props.currentStep === 3) {
       this.saveLabel = "View Plan";
+    } else {
+      this.saveLabel = "Next";
     }
     this.setHideSaveCancel(null, this.props.currentStep === 0);
   }


### PR DESCRIPTION
Once you get to the third page on the profile screen and backtrack to previous the next button switches to "view plan" for all pages.   The else block is needed in this case.  